### PR TITLE
fix: rotate landscape swapped coordinates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,7 +634,7 @@ where
             Orientation::Portrait => (phys_w - 1 - y, phys_h - 1 - x),
             Orientation::Landscape => (y, phys_h - 1 - x),
             Orientation::PortraitSwapped => (x, y),
-            Orientation::LandscapeSwapped => (y, phys_h - 1 - x),
+            Orientation::LandscapeSwapped => (phys_w - 1 - y, x),
         }
     }
 


### PR DESCRIPTION
## Summary
- Correct `LandscapeSwapped` framebuffer coordinate mapping so it differs from `Landscape` and performs the swapped landscape transform.

## Validation
- `cargo +stable fmt --all -- --check`
- `cargo +stable clippy --config "build.target=\"aarch64-apple-darwin\"" --config 'unstable.build-std=[]' --all-targets --all-features -- -D warnings`
- `cargo +stable test --config "build.target=\"aarch64-apple-darwin\"" --config 'unstable.build-std=[]' --verbose --features ""`
- `cargo +stable test --config "build.target=\"aarch64-apple-darwin\"" --config 'unstable.build-std=[]' --verbose --features async`
- `cargo +stable test --config "build.target=\"aarch64-apple-darwin\"" --config 'unstable.build-std=[]' --verbose --features defmt`
- `cargo +stable test --config "build.target=\"aarch64-apple-darwin\"" --config 'unstable.build-std=[]' --verbose --features async,defmt`

## References
- Spec: -
- Spec Disposition: not_needed
- Solutions: -
- Project Docs: -
- Spec Sync: n/a(spec-free)
- Spec Drift: none
- Solutions Sync: n/a(no related solution)
- Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->